### PR TITLE
Fixed issue with endpoint when a local endpoint isn't declared

### DIFF
--- a/modules/aws.js
+++ b/modules/aws.js
@@ -90,7 +90,7 @@ var AWS = function (options) {
  * @param {Object} [options.local]
  */
 function getEndpoint (options) {
-  if (options.local) {
+  if (options.local.address) {
     var port = options.local.port || '8080'
 
     return 'http://' + options.local.address + ':' + port


### PR DESCRIPTION
Because the `local` variable will always define an object, the check on `options.local` for validity is ALWAYS going to be true. Therefore, `getEndpoint` will always return the local endpoint even if the user did not declare it in their `options`. 

```js
// aws.js
var local = options.local || {} // This will always define a valid object
```

```js
// aws.js
function getEndpoint (options) {
  if (options.local) { // This will always be true
    var port = options.local.port || '8080'

    return 'http://' + options.local.address + ':' + port
  }

  // This code will never be called
  return 'https://' + getHost(options.region)
}
```